### PR TITLE
switch from v4.app.Fragment to app.Fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,21 +23,21 @@ android {
         dev {
             applicationId 'mhealth.mvax.dev'
             minSdkVersion 24
-            targetSdkVersion 26
+            targetSdkVersion 24
             signingConfig signingConfigs.development
             testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         }
         qa {
             applicationId 'mhealth.mvax.qa'
             minSdkVersion 24
-            targetSdkVersion 26
+            targetSdkVersion 24
             signingConfig signingConfigs.development
             testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         }
         prod {
             applicationId 'mhealth.mvax.prod'
             minSdkVersion 24
-            targetSdkVersion 26
+            targetSdkVersion 24
             testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         }
     }
@@ -65,7 +65,7 @@ dependencies {
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'com.android.support:support-v4:26.1.0'
+    implementation 'com.android.support:support-v13:26.1.0' // must use v13 for ViewPager
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.jjoe64:graphview:4.2.1'
@@ -82,7 +82,5 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     implementation files('libs/javax.mail.jar')
 }
-
-
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="mhealth.mvax">
 
-    <!-- To auto-complete the email text field in the login form with the user's emails -->
+    <!-- populate auto-complete with user emails -->
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
@@ -18,27 +18,27 @@
         android:roundIcon="@mipmap/logo"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
-        <activity
-            android:name=".activities.MainActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden"
-            android:launchMode="singleTop">
 
-            <!-- <intent-filter> -->
-            <!-- <action android:name="android.intent.action.MAIN" /> -->
-            <!-- <category android:name="android.intent.category.LAUNCHER" /> -->
-            <!-- </intent-filter> -->
-        </activity>
-        <activity
-            android:name=".auth.LoginActivity"
-            android:label="@string/title_activity_login"></activity>
         <activity
             android:name=".activities.SplashActivity"
             android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".auth.LoginActivity"
+            android:label="@string/title_activity_login" />
+
+        <activity
+            android:name=".activities.MainActivity"
+            android:launchMode="singleTop">
+            <!-- <intent-filter> -->
+            <!-- <action android:name="android.intent.action.MAIN" /> -->
+            <!-- <category android:name="android.intent.category.LAUNCHER" /> -->
+            <!-- </intent-filter> -->
         </activity>
 
         <!-- File provider, most of code from: https://stackoverflow.com/questions/38200282/android-os-fileuriexposedexception-file-storage-emulated-0-test-txt-exposed/38858040#38858040 -->

--- a/app/src/main/java/mhealth/mvax/activities/MainActivity.java
+++ b/app/src/main/java/mhealth/mvax/activities/MainActivity.java
@@ -19,13 +19,13 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.activities;
 
+import android.app.Activity;
+import android.app.Fragment;
+import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomNavigationView;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentTransaction;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.MenuItem;
 
@@ -41,7 +41,7 @@ import mhealth.mvax.dashboard.FormsFragment;
 import mhealth.mvax.records.search.SearchFragment;
 import mhealth.mvax.settings.SettingsFragment;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends Activity {
 
 
     protected void onCreate(Bundle savedInstanceState) {
@@ -59,7 +59,7 @@ public class MainActivity extends AppCompatActivity {
 
 
         //Manually displaying the first fragment - one time only
-        FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
+        FragmentTransaction transaction = getFragmentManager().beginTransaction();
         transaction.replace(R.id.frame_layout, SearchFragment.newInstance());
         transaction.commit();
 
@@ -93,7 +93,7 @@ public class MainActivity extends AppCompatActivity {
 
                         }
 
-                        FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
+                        FragmentTransaction transaction = getFragmentManager().beginTransaction();
                         transaction.replace(R.id.frame_layout, selectedFragment);
                         transaction.commit();
                         return true;

--- a/app/src/main/java/mhealth/mvax/alerts/AlertsFragment.java
+++ b/app/src/main/java/mhealth/mvax/alerts/AlertsFragment.java
@@ -19,6 +19,7 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.alerts;
 
+import android.app.Fragment;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,7 +28,6 @@ import android.widget.BaseExpandableListAdapter;
 import android.widget.ExpandableListView;
 import android.widget.TextView;
 import mhealth.mvax.R;
-import android.support.v4.app.Fragment;
 
 
 import com.google.firebase.auth.FirebaseAuth;

--- a/app/src/main/java/mhealth/mvax/auth/ApproveUsersFragment.java
+++ b/app/src/main/java/mhealth/mvax/auth/ApproveUsersFragment.java
@@ -20,9 +20,10 @@ License along with mVax; see the file LICENSE. If not, see
 package mhealth.mvax.auth;
 
 
+import android.app.Fragment;
+import android.app.FragmentTransaction;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.FragmentTransaction;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -49,7 +50,7 @@ import mhealth.mvax.model.user.UserWithUID;
  * @author Matthew Tribby
  * November, 2017
  */
-public class ApproveUsersFragment extends android.support.v4.app.Fragment {
+public class ApproveUsersFragment extends Fragment {
     public static final String FIRST_NAME = "FIRST_NAME";
     public static final String LAST_NAME = "LAST_NAME";
     public static final String EMAIL = "EMAIL";

--- a/app/src/main/java/mhealth/mvax/auth/CurrentUsersFragment.java
+++ b/app/src/main/java/mhealth/mvax/auth/CurrentUsersFragment.java
@@ -1,6 +1,7 @@
 package mhealth.mvax.auth;
 
 import android.app.AlertDialog;
+import android.app.Fragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -32,7 +33,7 @@ import mhealth.mvax.model.user.UserWithUID;
 /**
  * Matthew Tribby
  */
-public class CurrentUsersFragment extends android.support.v4.app.Fragment {
+public class CurrentUsersFragment extends Fragment {
 
     private ListView currentUsersLV;
     private List<UserWithUID> users;

--- a/app/src/main/java/mhealth/mvax/auth/LoginActivity.java
+++ b/app/src/main/java/mhealth/mvax/auth/LoginActivity.java
@@ -20,11 +20,11 @@ License along with mVax; see the file LICENSE. If not, see
 package mhealth.mvax.auth;
 
 import android.animation.ObjectAnimator;
+import android.app.Activity;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -57,7 +57,7 @@ import mhealth.mvax.auth.modals.RegisterModal;
  * Activity that handles user authentication, password reset, and new user registration;
  * all operations done via Firbase authentication and database API
  */
-public class LoginActivity extends AppCompatActivity {
+public class LoginActivity extends Activity {
 
     private static final int ANIMATION_SPEED = 500;
     private static final int ANIMATION_SPEED_INSTANT = 0;

--- a/app/src/main/java/mhealth/mvax/dashboard/DashboardFragment.java
+++ b/app/src/main/java/mhealth/mvax/dashboard/DashboardFragment.java
@@ -19,9 +19,9 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.dashboard;
 
+import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/mhealth/mvax/dashboard/FormsFragment.java
+++ b/app/src/main/java/mhealth/mvax/dashboard/FormsFragment.java
@@ -21,6 +21,7 @@ package mhealth.mvax.dashboard;
 
 
 import android.app.AlertDialog;
+import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
@@ -46,7 +47,7 @@ import mhealth.mvax.R;
  * @author Matthew Tribby
  * November, 2017
  */
-public class FormsFragment extends android.support.v4.app.Fragment {
+public class FormsFragment extends Fragment {
     private LayoutInflater inflater;
 
     public static FormsFragment newInstance() {

--- a/app/src/main/java/mhealth/mvax/records/record/DualTabPagerAdapter.java
+++ b/app/src/main/java/mhealth/mvax/records/record/DualTabPagerAdapter.java
@@ -19,9 +19,9 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.records.record;
 
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.support.v13.app.FragmentStatePagerAdapter;
 
 /**
  * @author Robert Steilberg

--- a/app/src/main/java/mhealth/mvax/records/record/RecordFragment.java
+++ b/app/src/main/java/mhealth/mvax/records/record/RecordFragment.java
@@ -19,9 +19,9 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.records.record;
 
+import android.app.Fragment;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
-import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/java/mhealth/mvax/records/record/patient/modify/ModifiablePatientFragment.java
+++ b/app/src/main/java/mhealth/mvax/records/record/patient/modify/ModifiablePatientFragment.java
@@ -19,8 +19,8 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.records.record.patient.modify;
 
+import android.app.Fragment;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -32,9 +32,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 
 import mhealth.mvax.R;
-//import mhealth.mvax.model.record.Guardian;
 import mhealth.mvax.model.record.Patient;
-//import mhealth.mvax.model.record.Person;
 import mhealth.mvax.records.record.RecordFragment;
 
 /**
@@ -131,14 +129,14 @@ public abstract class ModifiablePatientFragment extends Fragment {
     private void viewRecord() {
         // in case of create, pop "Edit -> Search" from back stack and commit it
         // in case of edit, pop "Edit -> Record" from back stack and commit it
-        getActivity().getSupportFragmentManager().popBackStack();
+        getActivity().getFragmentManager().popBackStack();
 
         // in case of create, back stack is empty, so nothing happens
         // in cse of edit, pop "Record -> Search" from back stack and commit it
-        getActivity().getSupportFragmentManager().popBackStack();
+        getActivity().getFragmentManager().popBackStack();
 
         // commit "Search -> Record", adding "Record -> Search" to back stack
-        getActivity().getSupportFragmentManager().beginTransaction()
+        getActivity().getFragmentManager().beginTransaction()
                 .replace(R.id.frame_layout, RecordFragment.newInstance(mPatient.getDatabaseKey()))
                 .addToBackStack(null)
                 .commit();

--- a/app/src/main/java/mhealth/mvax/records/record/patient/modify/edit/EditPatientFragment.java
+++ b/app/src/main/java/mhealth/mvax/records/record/patient/modify/edit/EditPatientFragment.java
@@ -106,9 +106,9 @@ public class EditPatientFragment extends ModifiablePatientFragment {
             public void onChildRemoved(DataSnapshot dataSnapshot) {
                 Toast.makeText(getActivity(), R.string.patient_delete, Toast.LENGTH_SHORT).show();
                 // pop "Edit -> Record" from back stack and commit it
-                getActivity().getSupportFragmentManager().popBackStack();
+                getActivity().getFragmentManager().popBackStack();
                 // pop "Record -> Search" from back stack and commit it
-                getActivity().getSupportFragmentManager().popBackStack();
+                getActivity().getFragmentManager().popBackStack();
             }
 
             @Override

--- a/app/src/main/java/mhealth/mvax/records/record/patient/view/PatientDetailsTab.java
+++ b/app/src/main/java/mhealth/mvax/records/record/patient/view/PatientDetailsTab.java
@@ -19,8 +19,8 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.records.record.patient.view;
 
+import android.app.Fragment;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -139,7 +139,7 @@ public class PatientDetailsTab extends Fragment implements RecordTab {
             public void onChildRemoved(DataSnapshot dataSnapshot) {
                 Toast.makeText(getActivity(), R.string.patient_delete, Toast.LENGTH_SHORT).show();
                 // pop "Record -> Search" from back stack and commit it
-                getActivity().getSupportFragmentManager().popBackStack();
+                getActivity().getFragmentManager().popBackStack();
             }
 
             @Override
@@ -171,18 +171,18 @@ public class PatientDetailsTab extends Fragment implements RecordTab {
             @Override
             public void onClick(View view) {
                 // pop "Record -> Search" from back stack and commit it
-                getActivity().getSupportFragmentManager().popBackStack();
+                getActivity().getFragmentManager().popBackStack();
 
                 // commit "Search -> Record, adding "Record -> Search to back stack
                 final RecordFragment onBackFrag = RecordFragment.newInstance(mPatient.getDatabaseKey());
-                getActivity().getSupportFragmentManager().beginTransaction()
+                getActivity().getFragmentManager().beginTransaction()
                         .replace(R.id.frame_layout, onBackFrag)
                         .addToBackStack(null)
                         .commit();
 
                 // commit "Record -> Edit", adding "Edit -> Record to back stack
                 final EditPatientFragment editDataFrag = EditPatientFragment.newInstance(mPatient);
-                getActivity().getSupportFragmentManager().beginTransaction()
+                getActivity().getFragmentManager().beginTransaction()
                         .replace(R.id.frame_layout, editDataFrag)
                         .addToBackStack(null)
                         .commit();

--- a/app/src/main/java/mhealth/mvax/records/record/vaccine/VaccineScheduleTab.java
+++ b/app/src/main/java/mhealth/mvax/records/record/vaccine/VaccineScheduleTab.java
@@ -19,8 +19,8 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.records.record.vaccine;
 
+import android.app.Fragment;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/mhealth/mvax/records/search/SearchFragment.java
+++ b/app/src/main/java/mhealth/mvax/records/search/SearchFragment.java
@@ -19,8 +19,8 @@ License along with mVax; see the file LICENSE. If not, see
 */
 package mhealth.mvax.records.search;
 
+import android.app.Fragment;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
@@ -107,7 +107,7 @@ public class SearchFragment extends Fragment {
         newRecordButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                getActivity().getSupportFragmentManager().beginTransaction()
+                getActivity().getFragmentManager().beginTransaction()
                         .replace(R.id.frame_layout, CreateRecordFragment.newInstance())
                         .addToBackStack(null) // back button brings us back to SearchFragment
                         .commit();
@@ -227,7 +227,7 @@ public class SearchFragment extends Fragment {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 final String selectedDatabaseKey = mSearchResultAdapter.getSelectedDatabaseKey(position);
                 final RecordFragment detailFrag = RecordFragment.newInstance(selectedDatabaseKey);
-                getActivity().getSupportFragmentManager().beginTransaction()
+                getActivity().getFragmentManager().beginTransaction()
                         .replace(R.id.frame_layout, detailFrag)
                         .addToBackStack(null) // back button brings us back to SearchFragment
                         .commit();

--- a/app/src/main/java/mhealth/mvax/settings/SettingsFragment.java
+++ b/app/src/main/java/mhealth/mvax/settings/SettingsFragment.java
@@ -20,13 +20,13 @@ License along with mVax; see the file LICENSE. If not, see
 package mhealth.mvax.settings;
 
 import android.app.AlertDialog;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomNavigationView;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -269,7 +269,7 @@ public class SettingsFragment extends Fragment {
     private void switchToApproveUsersFragment() {
         ApproveUsersFragment approveUsers = new ApproveUsersFragment();
 
-        FragmentTransaction transaction = getActivity().getSupportFragmentManager().beginTransaction();
+        FragmentTransaction transaction = getActivity().getFragmentManager().beginTransaction();
         transaction.replace(getId(), this).addToBackStack(null); // so that back button works
         transaction.replace(R.id.frame_layout, approveUsers);
         transaction.addToBackStack(null);
@@ -278,7 +278,7 @@ public class SettingsFragment extends Fragment {
 
     private void switchToCurrentUsersFragment(){
         Fragment fragment =  new CurrentUsersFragment();
-        FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
+        FragmentManager fragmentManager = getActivity().getFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
         fragmentTransaction.replace(R.id.frame_layout, fragment);
         fragmentTransaction.addToBackStack(null);


### PR DESCRIPTION
Switched all our Fragments from v4.app.Fragment to app.Fragment. I did this primarily to get rid of the title bar at the top of each screen. I also do not anticipate supporting pre-API 11 and pre-Android 2 devices, so I see no problem abandoning the support library.